### PR TITLE
[Chore] 온보딩 플로우  변경 및 Response 변경사항 반영

### DIFF
--- a/Motivoo-iOS/Motivoo-iOS.xcodeproj/project.pbxproj
+++ b/Motivoo-iOS/Motivoo-iOS.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		02E1042C2B570B0C003852A7 /* InviteCodeRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E1042B2B570B0C003852A7 /* InviteCodeRequest.swift */; };
 		02E1042E2B570B30003852A7 /* InviteCodeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E1042D2B570B30003852A7 /* InviteCodeResponse.swift */; };
 		02E104302B57916C003852A7 /* MatchingCheckResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E1042F2B57916C003852A7 /* MatchingCheckResponse.swift */; };
+		02E8704C2B960F9B00DD4B38 /* NewInviteCodeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E8704B2B960F9B00DD4B38 /* NewInviteCodeResponse.swift */; };
 		02F383182B5A404F00631BE9 /* OnboardingView3SecondCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F383172B5A404F00631BE9 /* OnboardingView3SecondCell.swift */; };
 		02F817332B46A22A00650E14 /* StartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F817322B46A22A00650E14 /* StartViewController.swift */; };
 		055A42B62B515EF50090DA73 /* HomeProveSuccessView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 055A42B52B515EF50090DA73 /* HomeProveSuccessView.swift */; };
@@ -229,6 +230,7 @@
 		02E1042B2B570B0C003852A7 /* InviteCodeRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeRequest.swift; sourceTree = "<group>"; };
 		02E1042D2B570B30003852A7 /* InviteCodeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteCodeResponse.swift; sourceTree = "<group>"; };
 		02E1042F2B57916C003852A7 /* MatchingCheckResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchingCheckResponse.swift; sourceTree = "<group>"; };
+		02E8704B2B960F9B00DD4B38 /* NewInviteCodeResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewInviteCodeResponse.swift; sourceTree = "<group>"; };
 		02F383172B5A404F00631BE9 /* OnboardingView3SecondCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingView3SecondCell.swift; sourceTree = "<group>"; };
 		02F817322B46A22A00650E14 /* StartViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartViewController.swift; sourceTree = "<group>"; };
 		055A42B52B515EF50090DA73 /* HomeProveSuccessView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeProveSuccessView.swift; sourceTree = "<group>"; };
@@ -673,6 +675,7 @@
 				02E104292B570598003852A7 /* UserExerciseResponse.swift */,
 				02E1042B2B570B0C003852A7 /* InviteCodeRequest.swift */,
 				02E1042D2B570B30003852A7 /* InviteCodeResponse.swift */,
+				02E8704B2B960F9B00DD4B38 /* NewInviteCodeResponse.swift */,
 				02E1042F2B57916C003852A7 /* MatchingCheckResponse.swift */,
 			);
 			path = Onboarding;
@@ -1092,6 +1095,7 @@
 				05AAF8D32B3EAA350079CEAB /* UITableViewHeaderFooterView+.swift in Sources */,
 				05C8FE592B4AA2A700A2838C /* HomeMissionModel.swift in Sources */,
 				05AAF90E2B47F0C30079CEAB /* MissionOverviewViewController.swift in Sources */,
+				02E8704C2B960F9B00DD4B38 /* NewInviteCodeResponse.swift in Sources */,
 				02E1040F2B557C2E003852A7 /* GenericResponse.swift in Sources */,
 				05AAF8F32B44F18D0079CEAB /* FontLiterals.swift in Sources */,
 				05AAF8AB2B3E5BFE0079CEAB /* UIView+.swift in Sources */,

--- a/Motivoo-iOS/Motivoo-iOS/Data/Onboarding/InviteCodeResponse.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Data/Onboarding/InviteCodeResponse.swift
@@ -9,14 +9,12 @@ import Foundation
 
 struct InviteCodeResponse: Codable {
     let userId: Int
+    let opponentUserId: Int
     let isMatched: Bool
-    let myInviteCode: Bool
-    let isFinishedOnboarding: Bool
 
     enum CodingKeys: String, CodingKey {
         case userId = "user_id"
+        case opponentUserId = "opponent_user_id"
         case isMatched = "is_matched"
-        case myInviteCode = "my_invite_code"
-        case isFinishedOnboarding = "is_finished_onboarding"
     }
 }

--- a/Motivoo-iOS/Motivoo-iOS/Data/Onboarding/NewInviteCodeResponse.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Data/Onboarding/NewInviteCodeResponse.swift
@@ -1,0 +1,21 @@
+//
+//  NewInviteCodeResponse.swift
+//  Motivoo-iOS
+//
+//  Created by 이조은 on 3/4/24.
+//
+
+import Foundation
+
+// MARK: - NewInviteCodeResponse
+struct NewInviteCodeResponse: Codable {
+    let userID: Int
+    let isMatched: Bool
+    let inviteCode: String
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "user_id"
+        case isMatched = "is_matched"
+        case inviteCode = "invite_code"
+    }
+}

--- a/Motivoo-iOS/Motivoo-iOS/Data/Onboarding/OnboardingExerciseResponse.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Data/Onboarding/OnboardingExerciseResponse.swift
@@ -9,12 +9,10 @@ import Foundation
 
 struct OnboardingExerciseResponse: Codable {
     let userID: Int
-    let inviteCode: String?
     let exerciseLevel: String
 
     enum CodingKeys: String, CodingKey {
         case userID = "user_id"
-        case inviteCode = "invite_code"
         case exerciseLevel = "exercise_level"
     }
 }

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/InputInvitationViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/InputInvitationViewController.swift
@@ -106,40 +106,22 @@ extension InputInvitationViewController {
             guard let result = self.validateResult(result) as? InviteCodeResponse else { return }
             print(result)
 
-            if !result.myInviteCode {
-                if result.isMatched {
-                    // 매치 O
-                    UserDefaultManager.shared.saveUserMatcehd(match: result.isMatched)
-                    self.inputInvitationView.inputTextField.layer.borderColor = UIColor.gray300.cgColor
-                    self.inputInvitationView.wrongLabel.isHidden = true
-                    if result.isFinishedOnboarding {
-                        // 온보딩 완료
-                        // 모티부 시작하기 홈VC로 이동
-                        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                        guard let delegate = sceneDelegate else {
-                            print("sceneDelegate가 할당 Error")
-                            return
-                        }
-                        let rootViewController = UINavigationController(rootViewController: MotivooTabBarController())
-                        delegate.window?.rootViewController = rootViewController
-                    } else {
-                        // 온보딩 안함
-                        // 온보딩 VC로 이동
-                        let onboardingViewController = OnboardingViewController()
-                        self.navigationController?.pushViewController(onboardingViewController, animated: true)
-                    }
-                } else {
-                    self.inputInvitationView.inputTextField.layer.borderColor = UIColor.pink.cgColor
-                    self.inputInvitationView.wrongLabel.isHidden = false
+            // myInviteCode: 내 코드인지 아닌지는 백엔드에서 검사하는건가? 이제?
+            if result.isMatched {
+                // 매치 O
+                UserDefaultManager.shared.saveUserMatcehd(match: result.isMatched)
+                self.inputInvitationView.inputTextField.layer.borderColor = UIColor.gray300.cgColor
+                self.inputInvitationView.wrongLabel.isHidden = true
+                // 온보딩 완료
+                // 모티부 시작하기 홈VC로 이동
+                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+                guard let delegate = sceneDelegate else {
+                    print("sceneDelegate가 할당 Error")
+                    return
                 }
+                let rootViewController = UINavigationController(rootViewController: MotivooTabBarController())
+                delegate.window?.rootViewController = rootViewController
             } else {
-                self.inputInvitationView.inputTextField.layer.borderColor = UIColor.pink.cgColor
-                self.inputInvitationView.wrongLabel.isHidden = false
-            }
-
-            if (result.isMatched && !result.myInviteCode) {
-            } else {
-                print("실패에에")
                 self.inputInvitationView.inputTextField.layer.borderColor = UIColor.pink.cgColor
                 self.inputInvitationView.wrongLabel.isHidden = false
             }

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/InvitationViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/InvitationViewController.swift
@@ -24,20 +24,7 @@ final class InvitationViewController: BaseViewController {
     // MARK: - Override Functions
     override func viewWillAppear(_ animated: Bool) {
         invitationView.codeLabel.text = invitationCode
-
-        invitationText =
-        """
-        자녀와 부모를 잇는 매일 한 걸음! 🏃‍♂️🩵 '모티부'에 초대받았어요.
-        매일 운동 미션을 수행하며 가족과 함께 건강 습관을 만들어 보아요!
-
-        https://gayeong04.notion.site/7f6097380a0b43d38ae265ea985152e7?pvs=4
-
-        1.위 링크로 들어가 모티부를 설치해요.
-        2.설치가 완료되면 로그인 후 '초대코드 입력하기' 버튼을 누르고 아래 초대코드를 입력하세요.
-        3.주어진 질문들에 답하면 맞춤 운동과 함께 자녀와의 운동이 시작됩니다 :)
-
-        초대코드: \(invitationCode)
-        """
+        invitationText = invitationCode
     }
 
     override func viewDidLoad() {

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/LoginViewController.swift
@@ -151,14 +151,12 @@ extension LoginViewController {
                 self.loginRetryLabel.isHidden = false
                 return
             }
-//            print("\n===0000======")
-//            print("result: \(result)")
-//            print("이름: \(result.nickname)")
-//            print("accessToken: \(result.accessToken)")
-//            print("refreshToken: \(result.refreshToken)")
-            print("=========TokenManager===")
+
+            print("=== postLogin result: \(result)")
+
             TokenManager.shared.saveToken(token: "Bearer \(result.accessToken)")
 
+            // 이용약관 분기처리 어카지 ??
             let isUserLoggedIn: Bool = UserDefaultManager.shared.getUserLoggedIn()
             if isUserLoggedIn {
                 // 로그인한 적이 있었다면 바아로 홈으로 진입
@@ -173,6 +171,32 @@ extension LoginViewController {
                 // 로그인한 적이 없다면 -> 이용약관에 동의한 적이 없다.
                 let termsOfUseViewController = TermsOfUseViewController()
                 self.navigationController?.pushViewController(termsOfUseViewController, animated: true)
+            }
+
+            let isMatched: Bool = UserDefaultManager.shared.getUserMatcehd()
+            let isFinished: Bool = UserDefaultManager.shared.getFinishedOnboarding()
+            let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+            guard let delegate = sceneDelegate else {
+                print("sceneDelegate가 할당 Error")
+                return
+            }
+
+            if isMatched && isFinished {
+                // 로그인 -> 온보딩 정보 입력 및 매칭 확인 ( 둘 다 true)
+                let rootViewController = UINavigationController(rootViewController: MotivooTabBarController())
+                delegate.window?.rootViewController = rootViewController
+            } else {
+                if isFinished {
+                    if !isMatched {
+                        // 온보딩은 입력했지만 매칭이 안된 경우는 StartVC
+                        let rootViewController = UINavigationController(rootViewController: StartViewController())
+                        delegate.window?.rootViewController = rootViewController
+                    }
+                } else {
+                    // 온보딩 정보 입력을 안했다면 OnboardingVC
+                    let rootViewController = UINavigationController(rootViewController: OnboardingViewController())
+                    delegate.window?.rootViewController = rootViewController
+                }
             }
         }
     }

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -20,13 +20,21 @@ final class OnboardingViewController: BaseViewController {
     lazy var selectButtonName3Second: String = ""
     lazy var selectButtonName4: String = ""
     lazy var selectButtonName5: String = ""
-
     lazy var questionArray: [String: Any] = ["type": "", "age": 0, "isExercise": true,
                                              "exerciseType":"", "exerciseCount":"", "exerciseTime":"", "exerciseNote":""]
 
     // MARK: - UI Component
 
     private lazy var onboardingProgressView = UIProgressView()
+
+    private let onboardingBackButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("이전", for: .normal)
+        button.setTitleColor(.gray700, for: .normal)
+        button.titleLabel?.font = .body6
+        return button
+    }()
+
     let onboardingCollectionView: UICollectionView = {
         var layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -56,14 +64,14 @@ final class OnboardingViewController: BaseViewController {
         super.viewWillAppear(false)
 
         setupNavigationBar()
-        self.customBackButton.removeTarget(self, action: #selector(backViewController), for: .touchUpInside)
-        self.customBackButton.addTarget(self, action: #selector(prevButtonDidTap), for: .touchUpInside)
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         setDelegate()
+        self.onboardingBackButton.isHidden = true
+        self.onboardingBackButton.addTarget(self, action: #selector(prevButtonDidTap), for: .touchUpInside)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -76,8 +84,6 @@ final class OnboardingViewController: BaseViewController {
             navigationArray.remove(at: navigationArray.count - 2) // 두 번째로 마지막인 FirstVC를 제거합니다.
             self.navigationController?.viewControllers = navigationArray // 수정된 스택을 다시 설정합니다.
         }
-        self.customBackButton.removeTarget(self, action: #selector(prevButtonDidTap), for: .touchUpInside)
-        self.customBackButton.addTarget(self, action: #selector(backViewController), for: .touchUpInside)
     }
 
     // MARK: - Override Functions
@@ -91,15 +97,21 @@ final class OnboardingViewController: BaseViewController {
     }
 
     override func setHierachy() {
-        self.view.addSubviews(onboardingProgressView, onboardingCollectionView)
+        self.view.addSubviews(onboardingBackButton, onboardingProgressView, onboardingCollectionView)
     }
 
     override func setLayout() {
+        onboardingBackButton.snp.makeConstraints {
+            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).offset(12)
+            $0.leading.equalToSuperview().inset(20)
+        }
+
         onboardingProgressView.snp.makeConstraints {
-            $0.top.equalTo(self.view.safeAreaLayoutGuide.snp.top)
+            $0.top.equalTo(onboardingBackButton.snp.bottom).offset(20.adjusted)
             $0.leading.trailing.equalToSuperview()
             $0.height.equalTo(2.adjusted)
         }
+
         onboardingCollectionView.snp.makeConstraints {
             $0.top.equalTo(onboardingProgressView.snp.bottom).offset(44.adjusted)
             $0.leading.trailing.bottom.equalToSuperview()
@@ -108,12 +120,8 @@ final class OnboardingViewController: BaseViewController {
 
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        self.navigationController?.isNavigationBarHidden = false
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .white
-        navigationController?.navigationBar.standardAppearance = appearance
-        navigationController?.navigationBar.compactAppearance = appearance
-        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+
+        self.navigationController?.isNavigationBarHidden = true
     }
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){
@@ -160,7 +168,7 @@ final class OnboardingViewController: BaseViewController {
             selectButtonName2 = ""
             questionArray["isExercise"] = nil
         }
-        print("buttonTap: \(selectButtonName2)")
+        // print("buttonTap: \(selectButtonName2)")
     }
 
     @objc
@@ -334,9 +342,6 @@ final class OnboardingViewController: BaseViewController {
 
     @objc
     private func prevButtonDidTap() {
-        // print("indexpath - 1")
-        print("=== prevButtonDidTap ===")
-        //print("prevButtonDidTapprevButtonDidTapprevButtonDidTapprevButtonDidTap")
         let currentIndexPath = self.onboardingCollectionView.indexPathsForVisibleItems.first
         if let currentIndexPath = currentIndexPath, currentIndexPath.row - 1 < self.onboardingCollectionView.numberOfItems(inSection: 0) {
             let prevIndexPath = IndexPath(row: currentIndexPath.row - 1, section: currentIndexPath.section)
@@ -347,7 +352,7 @@ final class OnboardingViewController: BaseViewController {
     @objc
     private func startMotivooButtonDidTap() {
         questionArray["exerciseNote"] = choiceThreeButtonArray
-        print(questionArray)
+        // print(questionArray)
         requestPostExerciseAPI(
             type: questionArray["type"] as? String ?? "",
             age: questionArray["age"] as? Int ?? 0,
@@ -376,6 +381,11 @@ extension OnboardingViewController : UICollectionViewDelegate, UICollectionViewD
         // print("Cell at \(indexPath.row/6) will display")
         let cellIndex = Float(indexPath.row + 1)
         onboardingProgressView.setProgress(cellIndex/6, animated: true)
+        if cellIndex == 1.0 {
+            self.onboardingBackButton.isHidden = true
+        } else {
+            self.onboardingBackButton.isHidden = false
+        }
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -388,7 +398,7 @@ extension OnboardingViewController : UICollectionViewDelegate, UICollectionViewD
             // 필요한 설정을 추가합니다.
             return cell
         } else if indexPath.row == 2 {
-            print("=====selectButtonName2: \(selectButtonName2)")
+            // print("=====selectButtonName2: \(selectButtonName2)")
             if (selectButtonName2 == "yes") {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OnboardingView3Cell.identifier, for: indexPath) as! OnboardingView3Cell
                 cell.highButton.addTarget(self, action: #selector(selectButtonDidTap3), for: .touchUpInside)
@@ -447,7 +457,7 @@ extension OnboardingViewController : UICollectionViewDelegate, UICollectionViewD
             return cell
         } else {
             // OnboardingView1Cell을 반환
-            self.customBackButton.addTarget(self, action: #selector(backViewController), for: .touchUpInside)
+            //self.customBackButton.addTarget(self, action: #selector(backViewController), for: .touchUpInside)
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: OnboardingView1Cell.identifier, for: indexPath) as! OnboardingView1Cell
             cell.nextButton.addTarget(self, action: #selector(nextButtonDidTap), for: .touchUpInside)
             return cell

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/OnboardingViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/OnboardingViewController.swift
@@ -461,23 +461,11 @@ extension OnboardingViewController {
         let param = OnboardingExerciseRequest(type: type, age: age, isExercise: isExercise, exerciseType: exerciseType, exerciseCount: exerciseCount, exerciseTime: exerciseTime, exerciseNote: exerciseNote)
         OnboardingAPI.shared.postExercise(param: param) { result in
             guard let result = self.validateResult(result) as? OnboardingExerciseResponse else { return }
-            // UserDefault에 inviteCode 저장
-            UserDefaultManager.shared.saveInviteCode(inviteCode: result.inviteCode ?? "")
+            // 온보딩 완료 저장
             UserDefaultManager.shared.saveFinishedOnboarding(finished: true)
-            let isMatched: Bool = UserDefaultManager.shared.getUserMatcehd()
-            if isMatched {
-                // 온보딩을 이전에 매칭이 완료된 경우
-                let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-                guard let delegate = sceneDelegate else {
-                    print("sceneDelegate가 할당 Error")
-                    return
-                }
-                let rootViewController = UINavigationController(rootViewController: MotivooTabBarController())
-                delegate.window?.rootViewController = rootViewController
-            } else {
-                let invitationViewController = InvitationViewController()
-                self.navigationController?.pushViewController(invitationViewController, animated: true)
-            }
+            // 모티부 시작하기 페이지로 이동
+            let startViewController = StartViewController()
+            self.navigationController?.pushViewController(startViewController, animated: true)
         }
     }
 }

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/SplashViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/SplashViewController.swift
@@ -19,16 +19,19 @@ final class SplashViewController: BaseViewController {
     var isUserLoggedIn: Bool = UserDefaultManager.shared.getUserLoggedIn()
     var token = TokenManager.shared.getToken()
     var isFinished: Bool = UserDefaultManager.shared.getFinishedOnboarding()
+    var isMached: Bool = UserDefaultManager.shared.getUserMatcehd()
 
     // MARK: - Life Cycles
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        // 변경!! 앱이 최초에 시작할 때 불러오는 방법은 없을까?
         self.isUserLoggedIn = UserDefaultManager.shared.getUserLoggedIn()
         self.token = TokenManager.shared.getToken()
         self.isFinished = UserDefaultManager.shared.getFinishedOnboarding()
-        print("\n========================")
+        self.isMached = UserDefaultManager.shared.getUserMatcehd()
+        print("\n============viewWillAppear============")
         print("===isUserLoggedIn: \(isUserLoggedIn)")
         print("===token: \(token)")
         print("===isFinished: \(isFinished)")
@@ -49,29 +52,24 @@ final class SplashViewController: BaseViewController {
                 return
             }
 
-            print("\n==========================")
+            print("\n==========viewDidLoad================")
             print(TokenManager.shared.getToken())
             print("==========================\n")
 
-            let isUserLoggedIn: Bool = UserDefaultManager.shared.getUserLoggedIn()
-            let token = TokenManager.shared.getToken()
-            let isFinished: Bool = UserDefaultManager.shared.getFinishedOnboarding()
-            let isMached: Bool = UserDefaultManager.shared.getUserMatcehd()
+            print("isUserLoggedIn: \(self.isUserLoggedIn)")
+            print("token: \(self.token)")
+            print("isFinished: \(self.isFinished)")
+            print("isMached: \(self.isMached)")
 
-            print("isUserLoggedIn: \(isUserLoggedIn)")
-            print("token: \(token)")
-            print("isFinished: \(isFinished)")
-            print("isMached: \(isMached)")
-
-            if token == "" {
+            if self.token == "" {
                 // token이 없다면
                 // 소셜로그인 화면으로 이동 (이후 이용약관)
                 let rootViewController = UINavigationController(rootViewController: LoginViewController())
                 delegate.window?.rootViewController = rootViewController
             } else {
                 // token이 있다면
-                if isFinished {
-                    if isMached {
+                if self.isFinished {
+                    if self.isMached {
                         let rootViewController = UINavigationController(rootViewController: MotivooTabBarController())
                         delegate.window?.rootViewController = rootViewController
                     } else {
@@ -83,19 +81,9 @@ final class SplashViewController: BaseViewController {
                     delegate.window?.rootViewController = rootViewController
                 }
                 return
-                // token는 있지만, 로그인 = false라면
-                // 카카오톡 회원가입은 했지만, 이용약관 허용을 아직 진행하지 않았음으로 이용 약관 페이지로 이동
-                let rootViewController = UINavigationController(rootViewController: TermsOfUseViewController())
-                delegate.window?.rootViewController = rootViewController
             }
         }
     }
-
-//    override func viewDidDisappear(_ animated: Bool) {
-//        navigationController?.isNavigationBarHidden = true
-//
-//        print("== spalsh: viewDidDisappear")
-//    }
 
     // MARK: - Override Functions
     override func setupNavigationBar() {
@@ -132,6 +120,16 @@ extension SplashViewController {
             UserDefaultManager.shared.saveFinishedOnboarding(finished: result.isFinishedOnboarding)
             print("===Finish:  \(result.isFinishedOnboarding)")
             self.isFinished = UserDefaultManager.shared.getFinishedOnboarding()
+        }
+    }
+
+    private func requestGetMatchingCheck() {
+        OnboardingAPI.shared.getMatchingCheck() { result in
+            guard let result = self.validateResult(result) as? MatchingCheckResponse
+            else { return }
+            if result.isMatched {
+                UserDefaultManager.shared.saveUserMatcehd(match: result.isMatched)
+            }
         }
     }
 }

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/SplashViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/SplashViewController.swift
@@ -19,7 +19,7 @@ final class SplashViewController: BaseViewController {
     var isUserLoggedIn: Bool = UserDefaultManager.shared.getUserLoggedIn()
     var token = TokenManager.shared.getToken()
     var isFinished: Bool = UserDefaultManager.shared.getFinishedOnboarding()
-    var isMached: Bool = UserDefaultManager.shared.getUserMatcehd()
+    var isMatched: Bool = UserDefaultManager.shared.getUserMatcehd()
 
     // MARK: - Life Cycles
 
@@ -30,7 +30,7 @@ final class SplashViewController: BaseViewController {
         self.isUserLoggedIn = UserDefaultManager.shared.getUserLoggedIn()
         self.token = TokenManager.shared.getToken()
         self.isFinished = UserDefaultManager.shared.getFinishedOnboarding()
-        self.isMached = UserDefaultManager.shared.getUserMatcehd()
+        self.isMatched = UserDefaultManager.shared.getUserMatcehd()
         print("\n============viewWillAppear============")
         print("===isUserLoggedIn: \(isUserLoggedIn)")
         print("===token: \(token)")
@@ -59,7 +59,7 @@ final class SplashViewController: BaseViewController {
             print("isUserLoggedIn: \(self.isUserLoggedIn)")
             print("token: \(self.token)")
             print("isFinished: \(self.isFinished)")
-            print("isMached: \(self.isMached)")
+            print("isMached: \(self.isMatched)")
 
             if self.token == "" {
                 // token이 없다면
@@ -69,7 +69,7 @@ final class SplashViewController: BaseViewController {
             } else {
                 // token이 있다면
                 if self.isFinished {
-                    if self.isMached {
+                    if self.isMatched {
                         let rootViewController = UINavigationController(rootViewController: MotivooTabBarController())
                         delegate.window?.rootViewController = rootViewController
                     } else {

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/StartViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/StartViewController.swift
@@ -20,33 +20,15 @@ final class StartViewController: BaseViewController {
     private let motivooTextLogo = UIImageView()
     private let sloganLabel = UILabel()
     private let imageView = UIImageView()
+    // 버튼 TextLiterals 수정 및 디자인 변경 반영 필요
     private let startMotivooButton = MotivooButton(text: TextLiterals.Onboarding.Login.motivooStart, buttonStyle: .gray900)
     private let invitationCodeButton = MotivooButton(text: TextLiterals.Onboarding.Login.invitationCode, buttonStyle: .gray100)
-    lazy var nextViewController: UIViewController = OnboardingViewController()
-
 
     // MARK: - Life Cycles
 
     override func viewWillAppear(_ animated: Bool) {
-        self.navigationController?.isNavigationBarHidden = true
-
-        requestGetUserExercise()
-        self.isMatched = UserDefaultManager.shared.getUserMatcehd()
-        self.isFinished = UserDefaultManager.shared.getFinishedOnboarding()
-
-        print("===StartVC ViewWillAppear: \(TokenManager.shared.getToken())")
-        print("===StartVC ViewWillAppear: \(UserDefaultManager.shared.getFinishedOnboarding())")
-
-        if !isMatched {
-            // 온보딩 정보를 입력했다면
-            if isFinished {
-                nextViewController = InvitationViewController()
-            } else {
-                nextViewController = OnboardingViewController()
-            }
-        } else {
-            nextViewController = OnboardingViewController()
-        }
+        setupNavigationBar()
+        requestPostInviteCode()
     }
 
     override func viewDidLoad() {
@@ -58,7 +40,7 @@ final class StartViewController: BaseViewController {
     override func setupNavigationBar() {
         super.setupNavigationBar()
 
-        self.navigationController?.isNavigationBarHidden = false
+        self.navigationController?.isNavigationBarHidden = true
     }
 
     override func setUI() {
@@ -119,27 +101,24 @@ final class StartViewController: BaseViewController {
 
     @objc
     private func startMotivooButtonDidTap() {
-        self.navigationController?.pushViewController(nextViewController, animated: true)
-
-        setupNavigationBar()
+        let invitationViewController = InvitationViewController()
+        self.navigationController?.pushViewController(invitationViewController, animated: true)
     }
 
     @objc
     private func invitationCodeButtonDidTap() {
         let inputInvitationViewController = InputInvitationViewController()
         self.navigationController?.pushViewController(inputInvitationViewController, animated: true)
-        setupNavigationBar()
     }
 }
 
 extension StartViewController {
-    private func requestGetUserExercise() {
-        OnboardingAPI.shared.getExercise() { result in
-            guard let result = self.validateResult(result) as? UserExerciseResponse else {
-                return
-            }
-            UserDefaultManager.shared.saveFinishedOnboarding(finished: result.isFinishedOnboarding)
-            print("===Finish:  \(result.isFinishedOnboarding)")
+    private func requestPostInviteCode() {
+        OnboardingAPI.shared.postInviteCode() { result in
+            guard let result = self.validateResult(result) as? NewInviteCodeResponse else { return }
+
+            UserDefaultManager.shared.saveInviteCode(inviteCode: result.inviteCode)
+            // print("==== invitationCode: \(self.invitationCode)")
         }
     }
 }

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/TermsOfUseViewController.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/ViewControllers/TermsOfUseViewController.swift
@@ -150,10 +150,8 @@ final class TermsOfUseViewController: BaseViewController {
 
     @objc
     func nextButtonDidTap() {
-        let startViewController = StartViewController()
-        self.navigationController?.pushViewController(startViewController, animated: true)
-
-        UserDefaultManager.shared.saveUserLoggedIn(login: true)
+        let onboardingViewController = OnboardingViewController()
+        self.navigationController?.pushViewController(onboardingViewController, animated: true)
     }
 }
 

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView1Cell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView1Cell.swift
@@ -147,7 +147,7 @@ final class OnboardingView1Cell: UICollectionViewCell {
 
     func setLayout() {
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(500.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView2Cell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView2Cell.swift
@@ -60,7 +60,7 @@ final class OnboardingView2Cell: UICollectionViewCell {
 
     func setLayout() {
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(500.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView3Cell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView3Cell.swift
@@ -75,7 +75,7 @@ final class OnboardingView3Cell: UICollectionViewCell {
 
     func setLayout() {
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(500.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView3SecondCell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView3SecondCell.swift
@@ -75,7 +75,7 @@ final class OnboardingView3SecondCell: UICollectionViewCell {
 
     func setLayout() {
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(500.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView4Cell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView4Cell.swift
@@ -65,7 +65,7 @@ final class OnboardingView4Cell: UICollectionViewCell {
 
     func setLayout() {
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(500.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView5Cell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView5Cell.swift
@@ -67,7 +67,7 @@ final class OnboardingView5Cell: UICollectionViewCell {
             $0.edges.equalToSuperview()
         }
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(400.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView6Cell.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Feature/Onboarding/Views/Cells/OnboardingView6Cell.swift
@@ -116,7 +116,7 @@ final class OnboardingView6Cell: UICollectionViewCell {
             $0.edges.equalToSuperview()
         }
         bgView.snp.makeConstraints {
-            $0.top.equalToSuperview()
+            $0.top.equalToSuperview().inset(20.adjusted)
             $0.centerX.equalToSuperview()
             $0.width.equalTo(335.adjusted)
             $0.height.equalTo(500.adjusted)

--- a/Motivoo-iOS/Motivoo-iOS/Global/Literals/TextLiterals.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Global/Literals/TextLiterals.swift
@@ -218,6 +218,7 @@ enum TextLiterals {
         static var getExercise = "/user/onboarding"
         static var patchInviteCode = "/parentchild/match"
         static var getMatchingCheck = "/onboarding/match"
+        static var postInviteCode = "/parentchild/invite"
     }
     enum URL {
         static var getMyInfo = "/user/me"

--- a/Motivoo-iOS/Motivoo-iOS/Network/Onboarding/OnboardingAPI.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Network/Onboarding/OnboardingAPI.swift
@@ -56,4 +56,13 @@ extension OnboardingAPI {
             )
         }
     }
+
+    public func postInviteCode(completion: @escaping (NetworkResult<Any>) -> Void) {
+        onboardingProvider.request(.postInviteCode) { (result) in
+            self.disposeNetwork(result,
+                                dataModel: NewInviteCodeResponse.self,
+                                completion: completion
+            )
+        }
+    }
 }

--- a/Motivoo-iOS/Motivoo-iOS/Network/Onboarding/OnboardingService.swift
+++ b/Motivoo-iOS/Motivoo-iOS/Network/Onboarding/OnboardingService.swift
@@ -15,6 +15,7 @@ enum OnboardingService {
     case getExercise
     case patchInviteCode(param: InviteCodeRequest)
     case getMatchingCheck
+    case postInviteCode
 }
 
 extension OnboardingService: BaseTargetType {
@@ -30,12 +31,14 @@ extension OnboardingService: BaseTargetType {
             return TextLiterals.URLs.patchInviteCode
         case .getMatchingCheck:
             return TextLiterals.URLs.getMatchingCheck
+        case .postInviteCode:
+            return TextLiterals.URLs.postInviteCode
         }
     }
 
     var method: Moya.Method {
         switch self {
-        case .postLogin, .postExercise:
+        case .postLogin, .postExercise, .postInviteCode:
             return .post
         case .getExercise, .getMatchingCheck:
             return .get
@@ -50,7 +53,7 @@ extension OnboardingService: BaseTargetType {
             return .requestJSONEncodable(param) // body로 request를 넘기기
         case .postExercise(let param):
             return .requestJSONEncodable(param)
-        case .getExercise, .getMatchingCheck:
+        case .getExercise, .getMatchingCheck, .postInviteCode:
             return .requestPlain
         case .patchInviteCode(let param):
             return .requestJSONEncodable(param)
@@ -61,7 +64,7 @@ extension OnboardingService: BaseTargetType {
         switch self {
         case .postLogin:
             return APIConstants.noTokenHeader
-        case .postExercise, .getExercise, .patchInviteCode, .getMatchingCheck:
+        case .postExercise, .getExercise, .patchInviteCode, .getMatchingCheck, .postInviteCode:
             return APIConstants.hasTokenHeader
         }
     }


### PR DESCRIPTION
## 🔥*Pull requests*

🪵 **작업한 브랜치**
<!-- 작업한 브랜치를 [카테고리/#이슈번호] 형태로 작성해주세요 -->
- feature/#71

👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 플로우 변경 (로그인 후 -> 바로 온보딩 시작 -> 초대 코드 입력 or 초대 코드 복사
- 플로우 변경에 따른 분기 처리
- 온보딩 백버튼 이슈 해결
- Response 수정 및 추가

## 🚨 PR POINT
<!-- 해당 PR의 핵심을 적어주세요. -->
- 온보딩에서... 원래 `이전` 버튼을 클릭하면... 네비게이션 컨트롤러에 있는 이전 버튼이 작동하는 이슈가 있어서...
그냥 온보딩에 들어오면 네비게이션 컨트롤러 hidden 시키고 온보딩용 백버튼 만들어 주었습니다!!

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Motivoo/Motivoo-iOS/assets/78733700/f9fcffec-4a41-4d5a-a071-c45c879c8326" width ="250">|

## ✏️ 배운점 & 참고 레퍼런스
- <!-- 여기에 무엇을 배웠는지 간단하게 작성해주세요! -->

## 📟 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #71 
